### PR TITLE
Tests for CAR endpoints.

### DIFF
--- a/carapp/schemes.py
+++ b/carapp/schemes.py
@@ -35,6 +35,7 @@ Schema for car-arguments parsing and validation of HTTP request objects.
 """
 
 CAR_ARGS = {
+    "id": fields.Int(),
     "car_title": fields.Str(required=True),
     "title": fields.Str(required=True),
     "condition": fields.Str(required=True),

--- a/test.py
+++ b/test.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest import mock
-from carapp import app, db, db_models, endpoints
+from carapp import app
 
 
 TEST_USER = {

--- a/test.py
+++ b/test.py
@@ -167,9 +167,9 @@ class TestRequestMethods(unittest.TestCase):
     @mock.patch("carapp.db.session")
     def test_post_car(self, MockSession, MockCar):
         CAR = {
-            "id": 100000,
+            "id": 10,
             "car_title": "Supercar",
-            "title": "Supercar_3000",
+            "title": "Supercar-3000",
             "condition": "New",
             "body_type": "Sedan",
             "brand": "Supercar",
@@ -193,8 +193,7 @@ class TestRequestMethods(unittest.TestCase):
             "warranty": "12 months",
             "fuel_consumption": "2l/100km",
             "drivetrain": "4matic",
-            "date_added": "2020-10-21 15:02:54.770364",
-            "user_id": 999,
+            "user_id": 1,
         }
         with app.test_client() as client:
             MockCar.return_value = CAR
@@ -208,7 +207,7 @@ class TestRequestMethods(unittest.TestCase):
     @mock.patch("carapp.db.session")
     def test_put_car(self, MockSession, MockCar):
         CAR = {
-            "id": 100000,
+            "id": 1,
             "car_title": "Supercar",
             "title": "Supercar 3000",
             "condition": "New",
@@ -234,12 +233,11 @@ class TestRequestMethods(unittest.TestCase):
             "warranty": "12 months",
             "fuel_consumption": "2l/100km",
             "drivetrain": "4matic",
-            "date_added": "2020-10-21 15:02:54.770364",
             "user_id": 999,
         }
         with app.test_client() as client:
             MockCar.query.filter_by.update.return_value = CAR
-            response = client.put("/car/100000", json=CAR)
+            response = client.put("/car/1", json=CAR)
             self.assertIsNotNone(response.get_json())
             self.assertIsInstance(response.get_json(), dict)
             self.assertEqual(response.status_code, 200)

--- a/test.py
+++ b/test.py
@@ -1,54 +1,83 @@
 import unittest
-import json
 from unittest import mock
 from carapp import app, db, db_models, endpoints
 
 
-test_user = {
+TEST_USER = {
     "id": 100000,
     "username": "Kenn",
     "account_type": "client",
 }
+TEST_CAR = {
+    "id": 100000,
+    "car_title": "Supercar",
+    "title": "Supercar 3000",
+    "condition": "New",
+    "body_type": "Sedan",
+    "brand": "Supercar",
+    "model": "Car",
+    "year_of_production": "3000",
+    "country_origin": "Supercountry",
+    "country_now": "Supercountry",
+    "city": "Supercity",
+    "mileage": "0 km",
+    "technical_condition": "Supercondition",
+    "gear_box": "Manual",
+    "fuel_type": "Gasoline",
+    "engine": "10 l (666 hp / 100 kW)",
+    "color": "White",
+    "safety": "Supersafe",
+    "wanted": "No",
+    "multimedia": "Subwoofer",
+    "comfort": "Supercomfort",
+    "picture": "Cool pic",
+    "price": "1000000$",
+    "warranty": "12 months",
+    "fuel_consumption": "2l/100km",
+    "drivetrain": "4matic",
+    "user_id": 999,
+}
 
 
-@mock.patch.object(endpoints, "User")
-# Easier solution (check endpoints.py)
-# @mock.patch("carapp.db_models.User")
 class TestRequestMethods(unittest.TestCase):
     maxDiff = None
 
+    @mock.patch("carapp.db_models.User")
     def test_get_user(self, MockUser):
         with app.test_client() as client:
-            MockUser.query.get.return_value = test_user
-            response = client.get("/users/100000")
+            MockUser.query.get.return_value = TEST_USER
+            response = client.get("/user/100000")
             self.assertIsNotNone(response)
             self.assertIsInstance(response.get_json(), dict)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.get_json()["id"], 100000)
 
+    @mock.patch("carapp.db_models.User")
     def test_get_user_failure(self, MockUser):
         with app.test_client() as client:
             MockUser.query.get.return_value = None
-            response = client.get("/users/100000")
+            response = client.get("/user/100000")
             self.assertIsNotNone(response)
             self.assertIsInstance(response.get_json(), dict)
             self.assertEqual(response.status_code, 404)
 
+    @mock.patch("carapp.db_models.User")
     def test_get_all_users(self, MockUser):
         with app.test_client() as client:
             MockUser.query.all.return_value = [
-                test_user,
+                TEST_USER,
             ]
             response = client.get("/users")
             self.assertIsNotNone(response)
             self.assertEqual(response.status_code, 200)
             self.assertIsInstance(response.get_json(), dict)
             self.assertIsInstance(response.get_json()["Users"][0], dict)
-            self.assertEqual(response.get_json()["Users"][0], test_user)
+            self.assertEqual(response.get_json()["Users"][0], TEST_USER)
 
+    @mock.patch("carapp.db_models.User")
     @mock.patch("carapp.db.session")
     def test_post_user(self, MockSession, MockUser):
-        tester = {
+        TESTER = {
             "id": 100000,
             "username": "Barbie",
             "password": "12134",
@@ -56,16 +85,17 @@ class TestRequestMethods(unittest.TestCase):
             "account_type": "test-client",
         }
         with app.test_client() as client:
-            MockUser.return_value = tester
-            response = client.post("/users", json=tester)
+            MockUser.return_value = TESTER
+            response = client.post("/user", json=TESTER)
             self.assertIsNotNone(response.get_json())
             self.assertIsInstance(response.get_json(), dict)
             self.assertEqual(response.status_code, 201)
-            self.assertEqual(response.get_json(), tester)
+            self.assertEqual(response.get_json(), TESTER)
 
+    @mock.patch("carapp.db_models.User")
     @mock.patch("carapp.db.session")
     def test_put_user(self, MockSession, MockUser):
-        tester = {
+        TESTER = {
             "id": 100000,
             "username": "Barbie",
             "password": "12134",
@@ -73,27 +103,164 @@ class TestRequestMethods(unittest.TestCase):
             "account_type": "test-client",
         }
         with app.test_client() as client:
-            MockUser.query.filter_by.update.return_value = tester
-            response = client.put("/users/100000", json=tester)
+            MockUser.query.filter_by.update.return_value = TESTER
+            response = client.put("/user/100000", json=TESTER)
             self.assertIsNotNone(response.get_json())
             self.assertIsInstance(response.get_json(), dict)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.get_json(), tester)
+            self.assertEqual(response.get_json(), TESTER)
 
+    @mock.patch("carapp.db_models.User")
     @mock.patch("carapp.db.session")
     def test_delete_user(self, MockSession, MockUser):
         with app.test_client() as client:
-            MockUser.query.get.return_value = test_user
-            response = client.delete("/users/100000")
+            MockUser.query.get.return_value = TEST_USER
+            response = client.delete("/user/100000")
             self.assertIsNotNone(response)
             self.assertEqual(response.status_code, 204)
             self.assertEqual(response.data, b"")
 
+    @mock.patch("carapp.db_models.User")
     def test_delete_user_failure(self, MockUser):
         with app.test_client() as client:
             MockUser.query.get.return_value = None
-            response = client.delete("/users/100000")
+            response = client.delete("/user/100000")
             self.assertIsNotNone(response)
             self.assertIsInstance(response.get_json(), dict)
             self.assertEqual(response.status_code, 404)
             self.assertEqual(response.get_json(), {"Reason": "No User with id=100000"})
+
+    @mock.patch("carapp.db_models.Car")
+    def test_get_car(self, MockCar):
+        with app.test_client() as client:
+            MockCar.query.get.return_value = TEST_CAR
+            response = client.get("/car/100000")
+            self.assertIsNotNone(response)
+            self.assertIsInstance(response.get_json(), dict)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.get_json()["id"], 100000)
+
+    @mock.patch("carapp.db_models.Car")
+    def test_get_car_failure(self, MockCar):
+        with app.test_client() as client:
+            MockCar.query.get.return_value = None
+            response = client.get("/car/100000")
+            self.assertIsNotNone(response)
+            self.assertIsInstance(response.get_json(), dict)
+            self.assertEqual(response.status_code, 404)
+
+    @mock.patch("carapp.db_models.Car")
+    def test_get_all_cars(self, MockCar):
+        with app.test_client() as client:
+            FILTER = {"color": "White"}
+            MockCar.query.filter_by(**FILTER).all.return_value = [
+                TEST_CAR,
+            ]
+            response = client.get("/cars?color=White")
+            self.assertIsNotNone(response)
+            self.assertEqual(response.status_code, 200)
+            self.assertIsInstance(response.get_json(), dict)
+            self.assertIsInstance(response.get_json()["Cars"][0], dict)
+            self.assertEqual(response.get_json()["Cars"][0], TEST_CAR)
+
+    @mock.patch("carapp.db_models.Car")
+    @mock.patch("carapp.db.session")
+    def test_post_car(self, MockSession, MockCar):
+        CAR = {
+            "id": 100000,
+            "car_title": "Supercar",
+            "title": "Supercar_3000",
+            "condition": "New",
+            "body_type": "Sedan",
+            "brand": "Supercar",
+            "model": "Car",
+            "year_of_production": "3000",
+            "country_origin": "Supercountry",
+            "country_now": "Supercountry",
+            "city": "Supercity",
+            "mileage": "0 km",
+            "technical_condition": "Supercondition",
+            "gear_box": "Manual",
+            "fuel_type": "Gasoline",
+            "engine": "10 l (666 hp / 100 kW)",
+            "color": "White",
+            "safety": "Supersafe",
+            "wanted": "No",
+            "multimedia": "Subwoofer",
+            "comfort": "Supercomfort",
+            "picture": "Cool pic",
+            "price": "1000000$",
+            "warranty": "12 months",
+            "fuel_consumption": "2l/100km",
+            "drivetrain": "4matic",
+            "date_added": "2020-10-21 15:02:54.770364",
+            "user_id": 999,
+        }
+        with app.test_client() as client:
+            MockCar.return_value = CAR
+            response = client.post("/car", json=CAR)
+            self.assertIsNotNone(response.get_json())
+            self.assertIsInstance(response.get_json(), dict)
+            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.get_json(), CAR)
+
+    @mock.patch("carapp.db_models.Car")
+    @mock.patch("carapp.db.session")
+    def test_put_car(self, MockSession, MockCar):
+        CAR = {
+            "id": 100000,
+            "car_title": "Supercar",
+            "title": "Supercar 3000",
+            "condition": "New",
+            "body_type": "Sedan",
+            "brand": "Supercar",
+            "model": "Car",
+            "year_of_production": "3000",
+            "country_origin": "Supercountry",
+            "country_now": "Supercountry",
+            "city": "Supercity",
+            "mileage": "0 km",
+            "technical_condition": "Supercondition",
+            "gear_box": "Manual",
+            "fuel_type": "Gasoline",
+            "engine": "10 l (666 hp / 100 kW)",
+            "color": "White",
+            "safety": "Supersafe",
+            "wanted": "No",
+            "multimedia": "Subwoofer",
+            "comfort": "Supercomfort",
+            "picture": "Cool pic",
+            "price": "1000000$",
+            "warranty": "12 months",
+            "fuel_consumption": "2l/100km",
+            "drivetrain": "4matic",
+            "date_added": "2020-10-21 15:02:54.770364",
+            "user_id": 999,
+        }
+        with app.test_client() as client:
+            MockCar.query.filter_by.update.return_value = CAR
+            response = client.put("/car/100000", json=CAR)
+            self.assertIsNotNone(response.get_json())
+            self.assertIsInstance(response.get_json(), dict)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.get_json(), CAR)
+
+    @mock.patch("carapp.db_models.Car")
+    @mock.patch("carapp.db.session")
+    def test_delete_car(self, MockSession, MockCar):
+        with app.test_client() as client:
+            MockCar.query.get.return_value = TEST_CAR
+            response = client.delete("/car/100000")
+            self.assertIsNotNone(response)
+            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.data, b"")
+
+    @mock.patch("carapp.db_models.Car")
+    def test_delete_car_failure(self, MockCar):
+        with app.test_client() as client:
+            MockCar.query.get.return_value = None
+            response = client.delete("/car/100000")
+            self.assertIsNotNone(response)
+            self.assertIsInstance(response.get_json(), dict)
+            self.assertEqual(response.status_code, 404)
+            self.assertEqual(response.get_json(), {"Reason": "No Car with id=100000"})


### PR DESCRIPTION
### Story:
[Create tests for car endpoints.](https://trello.com/c/DnPvfLTU/11-1-unit-tests-for-users-and-cars)

### Description:
We add more endpoints so it's time to cover them with tests.
Here what I did for now:
- Accordingly to the naming convention constants were named in _upper snail case_:
```diff
- test_user = {...}
+ TEST_USER = {...}
+ TEST_CAR = {...}
```
- Tests for car endpoints:
- [x] **GET**-,
- [x] **GET**- with filter, 
- [x] **DELETE**
- [x] **POST**-,
- [x] **PUT**- 
~~I'm not sure why **POST** and **PUT** don't work cause it's done in the same manner as **POST**- and **PUT**- for user:~~
<img width="808" alt="Screenshot 2020-11-23 at 11 53 30" src="https://user-images.githubusercontent.com/63915804/99951882-0bfa9480-2d7f-11eb-98e9-def8ac0a3a8d.png">
